### PR TITLE
feat: resolve graphsync from store if present

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "aegir": "^36.2.3",
     "blockstore-core": "^1.0.5",
     "ipfs-unixfs-importer": "^9.0.6",
+    "it-pair": "^1.0.0",
+    "libp2p-interfaces": "^2.0.1",
     "prettier": "^2.6.1"
   },
   "dependencies": {

--- a/src/graphsync.ts
+++ b/src/graphsync.ts
@@ -127,12 +127,15 @@ export class Request extends EventEmitter {
     this.loader = new AsyncLoader(blocks, this.incomingBlockHook.bind(this));
   }
 
-  async open(peer: PeerId, extensions?: {[key: string]: any}) {
-    const {stream} = await this.dialer.dialProtocol(peer, PROTOCOL);
-    await pipe(
-      [newRequest(this.id, this.root, this.selector, extensions)],
-      stream
-    );
+  open(peer: PeerId, extensions?: {[key: string]: any}) {
+    this.loader.setWaitNotify(async () => {
+      this.loader.notifyWaiting = false;
+      const {stream} = await this.dialer.dialProtocol(peer, PROTOCOL);
+      await pipe(
+        [newRequest(this.id, this.root, this.selector, extensions)],
+        stream
+      );
+    });
   }
 
   async drain() {

--- a/test/mock-libp2p.ts
+++ b/test/mock-libp2p.ts
@@ -1,0 +1,124 @@
+import type {HandlerProps, MuxedStream, Connection} from "libp2p";
+import {Connection as Conn} from "libp2p-interfaces/src/connection";
+import PeerId from "peer-id";
+import {Multiaddr} from "multiaddr";
+import {EventEmitter} from "events";
+// @ts-ignore
+import pair from "it-pair";
+import type BufferList from "bl/BufferList";
+import drain from "it-drain";
+
+class MockAddressBook {
+  addrs: {[key: string]: Multiaddr[]} = {};
+
+  add(pid: PeerId, addrs: Multiaddr[]) {
+    this.addrs[pid.toString()] = addrs;
+    return this;
+  }
+}
+
+export class MockLibp2p {
+  streamId = 0;
+  handlers: {[key: string]: (props: HandlerProps) => void} = {};
+
+  peerId: PeerId;
+  connectionManager = new EventEmitter();
+  peerStore = {
+    addressBook: new MockAddressBook(),
+  };
+
+  sources: {[key: string]: AsyncIterable<BufferList>} = {};
+
+  constructor(peerId: PeerId) {
+    this.peerId = peerId;
+  }
+
+  handle(protocol: string, handler: (props: HandlerProps) => void) {
+    this.handlers[protocol] = handler;
+  }
+
+  unhandle(protocol: string | string[]) {
+    const protos = Array.isArray(protocol) ? protocol : [protocol];
+    protos.forEach((p) => {
+      delete this.handlers[p];
+    });
+  }
+
+  async dial(
+    peer: string | PeerId | Multiaddr,
+    options?: any
+  ): Promise<Connection> {
+    const localAddr = new Multiaddr("/ip4/127.0.0.1/tcp/8080");
+    const remoteAddr = new Multiaddr("/ip4/127.0.0.1/tcp/8081");
+
+    const [localPeer, remotePeer] = [
+      PeerId.createFromB58String(
+        "12D3KooWSoLzampfxc4t3sy9z7yq1Cgzbi7zGXpV7nvt5hfeKUhR"
+      ),
+      PeerId.createFromB58String(
+        "12D3KooWSoLzampfxc4t3sy9z7yq1Cgzbi7zGXpV7nvt5hfeKRhU"
+      ),
+    ];
+    const openStreams: MuxedStream[] = [];
+    let streamId = 0;
+
+    return new Conn({
+      localPeer: localPeer,
+      remotePeer: remotePeer,
+      localAddr,
+      remoteAddr,
+      stat: {
+        timeline: {
+          open: Date.now() - 10,
+          upgraded: Date.now(),
+        },
+        direction: "outbound",
+        encryption: "/noise",
+        multiplexer: "/mplex/6.7.0",
+      },
+      newStream: async (protocols) => {
+        const id = streamId++;
+        const stream = pair();
+
+        stream.close = () => stream.sink([]);
+        stream.id = id;
+
+        openStreams.push(stream);
+
+        return {
+          stream,
+          protocol: protocols[0],
+        };
+      },
+      close: async () => {},
+      getStreams: () => openStreams,
+    });
+  }
+
+  async dialProtocol(
+    peer: PeerId,
+    protocols: string[] | string,
+    options?: any
+  ): Promise<{stream: MuxedStream; protocol: string}> {
+    const id = "" + this.streamId++;
+    const stream: MuxedStream =
+      id in this.sources
+        ? {
+            source: this.sources[id],
+            sink: drain,
+          }
+        : pair();
+    stream.close = () => {};
+    stream.id = id;
+
+    const conn = {
+      stream,
+      protocol: typeof protocols === "string" ? protocols : protocols[0],
+    };
+    if (id in this.sources) {
+      // @ts-ignore
+      this.handlers[conn.protocol]({stream, connection: conn});
+    }
+    return conn;
+  }
+}

--- a/test/resolver.spec.ts
+++ b/test/resolver.spec.ts
@@ -1,5 +1,12 @@
 import {expect} from "aegir/utils/chai.js";
-import {unixfsPathSelector} from "../src/resolver";
+import {resolve, unixfsPathSelector} from "../src/resolver";
+import {MemoryBlockstore} from "blockstore-core/memory";
+import {MockLibp2p} from "./mock-libp2p";
+import PeerId from "peer-id";
+import {multiaddr} from "multiaddr";
+import {GraphSync} from "../src/graphsync";
+import {importer} from "ipfs-unixfs-importer";
+import {concat as concatUint8Arrays} from "uint8arrays/concat";
 
 describe("resolver", () => {
   it("parse a unixfs path", () => {
@@ -8,5 +15,60 @@ describe("resolver", () => {
         "bafyreiakhbtbs4tducqx5tcw36kdwodl6fdg43wnqaxmm64acckxhakeua/pictures/StefansCat.jpg"
       )
     ).to.not.throw();
+  });
+
+  it("resolves a unixfs directory from the store", async () => {
+    const blocks = new MemoryBlockstore();
+
+    const first = new Uint8Array(5 * 256);
+    const second = new Uint8Array(3 * 256);
+
+    // chunk and dagify it then get the root cid
+    let cid;
+    for await (const chunk of importer(
+      [
+        {path: "first", content: first},
+        {path: "second", content: second},
+      ],
+      blocks,
+      {
+        cidVersion: 1,
+        maxChunkSize: 256,
+        rawLeaves: true,
+        wrapWithDirectory: true,
+      }
+    )) {
+      if (chunk.path === "") {
+        cid = chunk.cid;
+      }
+    }
+
+    const libp2p = new MockLibp2p(
+      PeerId.createFromB58String(
+        "12D3KooWSoLzampfxc4t3sy9z7yq1Cgzbi7zGXpV7nvt5hfeKUhR"
+      )
+    );
+    const exchange = new GraphSync(libp2p, blocks);
+
+    if (!cid) {
+      throw new Error("failed to import DAG");
+    }
+    const content = resolve(
+      cid.toString() + "/first",
+      multiaddr(
+        "/ip4/127.0.0.1/tcp/41505/ws/p2p/12D3KooWSWERLeRUwpGrigog1Aa3riz9zBSShBPqdMcqYsPs7Bfw"
+      ),
+      exchange
+    );
+    const iterator = content[Symbol.asyncIterator]();
+    let {value, done} = await iterator.next();
+    let buf = value;
+    while (!done) {
+      ({value, done} = await iterator.next());
+      if (value) {
+        buf = concatUint8Arrays([buf, value], buf.length + value.length);
+      }
+    }
+    expect(buf).to.deep.equal(first);
   });
 });


### PR DESCRIPTION
When resolving a DAG, graphsync will not fire a request unless the blocks are absent from the store.